### PR TITLE
feat(wait): add configurable wait time between courses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ PASSWORD="你的统一身份认证密码"
 PATH="C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"  # 你的Edge/Chrome浏览器可执行文件路径
 HEADLESS="True"  # 是否启用无头模式，True表示不显示浏览器窗口，False表示显示浏览器窗口
 START_TIME="13:00:00"  # 可选，计划开始时间，格式为 HH:MM:SS
+WAIT_TIME="3"  # 可选，选课之间等待的时间，单位为秒，默认为 3 秒，间隔时间过短可能导致选课失败

--- a/hunter.py
+++ b/hunter.py
@@ -14,13 +14,14 @@ colorama.init()  # 初始化 colorama
 
 
 def run_course_hunter(
-    courses: list[dict[str, str]], headers: dict[str, str]
+    courses: list[dict[str, str]], headers: dict[str, str], wait_time: int
 ) -> list[dict[str, str]]:
     """执行选课流程
 
     Args:
         courses (list[dict[str, str]]): 要选择的课程列表
         headers (dict[str, str]): HTTP 请求头
+        wait_time (int): 每次尝试选课之间的等待时间（秒）
 
     Returns:
         list[dict]: 选课失败的课程列表
@@ -30,7 +31,7 @@ def run_course_hunter(
         status = add_course(course, headers)
         if not status:
             unsuccessful_courses.append(course)
-        for i in range(2, 0, -1):
+        for i in range(wait_time, 0, -1):
             print(f"\r{Fore.CYAN}等待 {i} 秒后继续...{Fore.RESET}", end="")
             time.sleep(1)
         print("\r" + " " * 50 + "\r", end="")  # 清除倒计时行
@@ -48,6 +49,7 @@ def main():
         courses = load_courses()
         config = load_config()
         headers = get_headers(config["COOKIES"])
+        wait_time = int(config.get("WAIT_TIME", 3))
 
         start_time = config.get("START_TIME")
         if start_time:
@@ -56,7 +58,7 @@ def main():
         else:
             print(Fore.GREEN + "未设置开始时间，直接开始抢课！" + Fore.RESET)
 
-        unsuccessful_courses = run_course_hunter(courses, headers)
+        unsuccessful_courses = run_course_hunter(courses, headers, wait_time)
 
     except (FileNotFoundError, ValueError) as e:
         print(Fore.RED + f"错误: {str(e)}" + Fore.RESET)


### PR DESCRIPTION
Add WAIT_TIME configuration option to control the interval between course selection attempts. This helps prevent selection failures due to request rate limitations. Default value is 3 seconds.