### PR TITLE
docs: remove Build and Release badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # 🎯 HITSZ 自动化选课脚本
 
-[![Build and Release](https://github.com/AbyssSkb/HITCourseHunter/actions/workflows/release.yml/badge.svg)](https://github.com/AbyssSkb/HITCourseHunter/actions/workflows/release.yml)
 [![CI](https://github.com/AbyssSkb/HITCourseHunter/actions/workflows/ci.yml/badge.svg)](https://github.com/AbyssSkb/HITCourseHunter/actions/workflows/ci.yml)
 
 ## ⚠️ 注意事项


### PR DESCRIPTION
The build and release status badge has been removed from the project README while keeping the CI badge intact.