### PR TITLE
feat: enable Renovate pre-commit hooks support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
   ],
   "lockFileMaintenance": {
     "enabled": true
+  },
+  "pre-commit": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
Add pre-commit configuration to Renovate to automatically update pre-commit hook versions in the repository configuration.